### PR TITLE
"Suppression d'abonnement via Stripe (POST /subscription/cancel)

### DIFF
--- a/subscriptions/src/main/java/com/cyna/subscriptions/controllers/StripeController.java
+++ b/subscriptions/src/main/java/com/cyna/subscriptions/controllers/StripeController.java
@@ -110,8 +110,9 @@ public class StripeController {
 
     @PostMapping("/subscription/cancel")
     public ResponseEntity<Object> cancelSubscription(@RequestBody SubscriptionDto subscriptionDto){
-        return ResponseEntity.ok(stripeService.cancelSubscription(subscriptionDto.getCustomerId()));
+        return ResponseEntity.ok(stripeService.cancelSubscription(subscriptionDto.getSubscriptionId()));
     }
+
 
     @PostMapping("/webhook")
     public ResponseEntity<Object> webhook(@RequestHeader("Stripe-Signature") String sigHeader, @RequestBody String payload){


### PR DESCRIPTION
🔹 Ajout d'une méthode cancelSubscription(String subscriptionId) 🔹 Correction du controller : passage de customerId → subscriptionId 🔹 Ajout de logs et gestion des erreurs Stripe plus robustes 🔹 Suppression du retour brut Stripe (incompatible Jackson) 🔹 Webhook : désérialisation sécurisée (type + fallback OK)"