### PR TITLE
Sub id in db

### DIFF
--- a/subscriptions/src/main/java/com/cyna/subscriptions/controllers/StripeController.java
+++ b/subscriptions/src/main/java/com/cyna/subscriptions/controllers/StripeController.java
@@ -53,7 +53,6 @@ public class StripeController {
     @GetMapping(params = "customerId")
     public ResponseEntity<List<SubscriptionDto>> getSubscriptionByCustomerId(@RequestParam("customerId") String customerId){
         // Nouvelle implémentation : appeler le StripeService pour récupérer depuis Stripe
-        // Note: Le type de retour est maintenant List<SubscriptionDto> car mapStripeSubscriptionToDto renvoie des SubscriptionDto
         List<SubscriptionDto> subscriptionsFromStripe = stripeService.listSubscriptionsByCustomer(customerId);
 
         if (subscriptionsFromStripe.isEmpty()) {

--- a/subscriptions/src/main/java/com/cyna/subscriptions/dto/PaymentMethodResponseDto.java
+++ b/subscriptions/src/main/java/com/cyna/subscriptions/dto/PaymentMethodResponseDto.java
@@ -13,6 +13,6 @@ public class PaymentMethodResponseDto {
     private int expiryYear;
     private String type;
     private String cardholderName;
-    @JsonProperty("isDefault") //soucis d'intéraction/sérialisation Lombok-> JSON de br1
+    @JsonProperty("isDefault")
     private boolean isDefault;
 }

--- a/subscriptions/src/main/java/com/cyna/subscriptions/models/Subscription.java
+++ b/subscriptions/src/main/java/com/cyna/subscriptions/models/Subscription.java
@@ -8,27 +8,31 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.Date;
 
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
 @Builder
+@Table(name = "subscription")
 public class Subscription {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // And Id provide by stripe
+    // Id stripe
     @Column(nullable = false, unique = true, name = "subscriptionId")
     private String subscriptionId;
 
-    @JoinColumn(name = "customer_id", nullable = false)
+    @Column(name = "customer_id", nullable = false)
     private String customerId;
 
-    @JoinColumn(name = "productId", nullable = false)
+    @Column(name = "productId", nullable = false)
     private Long productId;
+
+
+    @Column(name = "price_id", nullable = false)
+    private String priceId;
 
     @Column(nullable = false)
     private String orderNumber;

--- a/subscriptions/src/main/java/com/cyna/subscriptions/services/SubscriptionsService.java
+++ b/subscriptions/src/main/java/com/cyna/subscriptions/services/SubscriptionsService.java
@@ -26,7 +26,22 @@ public class SubscriptionsService {
     private StripeService stripeService;
 
     public Subscription create(Subscription subscription) {
-        return subscriptionRepo.save(subscription);
+        try {
+            log.info("[SubscriptionsService][create] Attempting to save subscription with subscriptionId: {}",
+                    subscription.getSubscriptionId());
+            log.info("[SubscriptionsService][create] Subscription details - customerId: {}, productId: {}, amount: {}, quantity: {}",
+                    subscription.getCustomerId(), subscription.getProductId(), subscription.getAmount(), subscription.getQuantity());
+
+            Subscription savedSubscription = subscriptionRepo.save(subscription);
+
+            log.info("[SubscriptionsService][create] Successfully saved subscription with internal ID: {} and subscriptionId: {}",
+                    savedSubscription.getId(), savedSubscription.getSubscriptionId());
+
+            return savedSubscription;
+        } catch (Exception e) {
+            log.error("[SubscriptionsService][create] Error saving subscription: {}", e.getMessage(), e);
+            throw e;
+        }
     }
 
     public void delete(String subscriptionId) {

--- a/subscriptions/src/main/java/com/cyna/subscriptions/services/SubscriptionsService.java
+++ b/subscriptions/src/main/java/com/cyna/subscriptions/services/SubscriptionsService.java
@@ -78,7 +78,7 @@ public class SubscriptionsService {
 
     public void update(Subscription subscription) {
 
-        // TODO : Implementer une logique de validation coté client avant de modifier la subscription.
+        // 📍TODO : Implementer une logique de validation coté client avant de modifier la subscription.
 
         Subscription initialSubscription = subscriptionRepo.findById(subscription.getId()).orElseThrow();
 


### PR DESCRIPTION
feat: Ajout de priceId à l'entité Subscription et persistance correcte

Ce commit résout l'erreur DataIntegrityViolationException causée par le champ 'priceId' qui n'était pas persisté dans la table 'subscription'.

Les changements clés incluent :
- **Mise à jour du modèle `Subscription.java`**: Ajout du champ `priceId` avec `@Column(name = "price_id", nullable = false)` pour le mapper correctement au schéma de la base de données et assurer sa non-nullabilité.
- **Assurance du renseignement de `priceId` dans `StripeService`**: Modification des méthodes `createSubscription` et `processSubscriptionCreated` pour extraire le `priceId` des réponses de l'API Stripe et l'inclure lors de la construction des entités `Subscription`.
- **Synchronisation du schéma de la base de données**: Confirmation que la table `subscription` dans la base de données inclut maintenant la colonne `price_id`, via `ddl-auto=create-drop` ou une exécution DDL manuelle, résolvant ainsi l'incohérence du schéma.

Ces modifications garantissent la cohérence des données entre la plateforme Stripe, les DTO de l'application et la base de données locale.